### PR TITLE
Add Claude plugin configuration and gitignore

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "common@jd": true
+  },
+  "extraKnownMarketplaces": {
+    "jd": {
+      "source": {
+        "source": "github",
+        "repo": "starburst997/claude"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION

## Summary

This PR adds Claude Code plugin configuration to enable custom plugins from a GitHub marketplace source. It also adds a `.gitignore` file to exclude macOS system files.

**Changes:**
- Created `.claude/settings.json` to configure the `common@jd` plugin from the `starburst997/claude` GitHub repository
- Added `.gitignore` to exclude `.DS_Store` files

## Test Plan

- [ ] Verify that Claude Code recognizes the plugin configuration
- [ ] Confirm the `common@jd` plugin is loaded and functional
- [ ] Check that `.DS_Store` files are properly ignored by git